### PR TITLE
feat(ui): add golden glimmer + hover sparkle effect to CTA buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,3 +13,84 @@ html, body, #__next {
 body {
   background-color: #0a0a0a;
 }
+
+.cta-gold {
+  position: relative;
+  overflow: hidden;
+  border-radius: 9999px;
+}
+
+.cta-gold::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 1px;
+  border-radius: inherit;
+  background: linear-gradient(130deg, #c3a46c, #f7e7c0, #c3a46c);
+  background-size: 200% 200%;
+  animation: glimmer 3s linear infinite;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+}
+
+.cta-gold > span {
+  position: relative;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: #0a0a0a;
+}
+
+.sparkle {
+  position: absolute;
+  top: 0.35rem;
+  right: 1rem;
+  font-size: 0.75rem;
+  color: #f7e7c0;
+  opacity: 0;
+  transform: scale(0);
+  pointer-events: none;
+}
+
+.cta-gold:hover .sparkle {
+  animation: sparkle 0.7s ease-out forwards;
+}
+
+@keyframes glimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+@keyframes sparkle {
+  0% {
+    transform: scale(0) rotate(0deg);
+    opacity: 1;
+  }
+  80% {
+    transform: scale(1) rotate(180deg);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1.4) rotate(240deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cta-gold::before {
+    animation: none;
+  }
+  .cta-gold:hover .sparkle {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,15 +70,11 @@ function CTAButton({ children, onClick }: { children: React.ReactNode; onClick?:
   return (
     <button
       onClick={onClick}
-      className="group relative inline-flex items-center justify-center overflow-hidden rounded-full px-6 py-3 text-sm font-medium transition"
+      className="cta-gold relative inline-flex items-center justify-center px-6 py-3 text-sm font-medium"
+      style={{ color: brand.ink }}
     >
-      <span
-        className="absolute inset-0"
-        style={{ background: `linear-gradient(120deg, ${brand.accentSoft}, transparent)`, border: `1px solid ${brand.accent}` }}
-      ></span>
-      <span className="relative" style={{ color: brand.ink }}>
-        {children}
-      </span>
+      <span>{children}</span>
+      <span className="sparkle">✦</span>
     </button>
   );
 }


### PR DESCRIPTION
Adds animated gold glimmer borders and ✦ hover sparkle effect to CTA buttons. Includes reduced-motion fallback. Vercel should attach a preview.

------
https://chatgpt.com/codex/tasks/task_e_68be360b1a1c8326a6d90c71e104c240