### PR TITLE
fix: remove button hover effects and prevent text wrapping

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,20 +46,6 @@ body {
   background: #0a0a0a;
 }
 
-.sparkle {
-  position: absolute;
-  top: 0.35rem;
-  right: 1rem;
-  font-size: 0.75rem;
-  color: #f7e7c0;
-  opacity: 0;
-  transform: scale(0);
-  pointer-events: none;
-}
-
-.cta-gold:hover .sparkle {
-  animation: sparkle 0.7s ease-out forwards;
-}
 
 @keyframes glimmer {
   0% {
@@ -70,27 +56,8 @@ body {
   }
 }
 
-@keyframes sparkle {
-  0% {
-    transform: scale(0) rotate(0deg);
-    opacity: 1;
-  }
-  80% {
-    transform: scale(1) rotate(180deg);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1.4) rotate(240deg);
-    opacity: 0;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .cta-gold::before {
     animation: none;
-  }
-  .cta-gold:hover .sparkle {
-    animation: none;
-    opacity: 1;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,11 +70,10 @@ function CTAButton({ children, onClick }: { children: React.ReactNode; onClick?:
   return (
     <button
       onClick={onClick}
-      className="cta-gold relative inline-flex items-center justify-center px-6 py-3 text-sm font-medium"
+      className="cta-gold relative inline-flex shrink-0 items-center justify-center px-6 py-3 text-sm font-medium whitespace-nowrap"
       style={{ color: brand.ink }}
     >
       <span>{children}</span>
-      <span className="sparkle">✦</span>
     </button>
   );
 }
@@ -142,7 +141,7 @@ function IntakeModal({ open, onClose }: { open: boolean; onClose: () => void }) 
               <button
                 key={s.key}
                 onClick={() => setSegment(s.key)}
-                className={`rounded-full border px-4 py-2 text-sm ${segment === s.key ? "opacity-100" : "opacity-60"}`}
+                className={`rounded-full border px-4 py-2 text-sm shrink-0 whitespace-nowrap ${segment === s.key ? "opacity-100" : "opacity-60"}`}
                 style={{ borderColor: brand.accent, color: brand.ink }}
               >
                 {s.title}
@@ -295,18 +294,10 @@ export default function Page() {
             </span>
           </div>
           <nav className="hidden gap-6 md:flex text-sm" style={{ color: brand.sub }}>
-            <a href="#manifesto" className="hover:text-white">
-              Manifesto
-            </a>
-            <a href="#concierge" className="hover:text-white">
-              Concierge
-            </a>
-            <a href="#process" className="hover:text-white">
-              Process
-            </a>
-            <a href="#contact" className="hover:text-white">
-              Contact
-            </a>
+            <a href="#manifesto">Manifesto</a>
+            <a href="#concierge">Concierge</a>
+            <a href="#process">Process</a>
+            <a href="#contact">Contact</a>
           </nav>
           <CTAButton onClick={() => setOpen(true)}>Start your brief</CTAButton>
         </div>
@@ -331,7 +322,7 @@ export default function Page() {
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <CTAButton onClick={() => setOpen(true)}>Tell us your brief</CTAButton>
-              <button className="rounded-full border px-6 py-3 text-sm" style={{ borderColor: brand.ring, color: brand.ink }}>
+              <button className="rounded-full border px-6 py-3 text-sm shrink-0 whitespace-nowrap" style={{ borderColor: brand.ring, color: brand.ink }}>
                 See how it works
               </button>
             </div>


### PR DESCRIPTION
## Summary
- prevent button text from wrapping by adding `shrink-0 whitespace-nowrap`
- remove sparkle hover animation and navigation link hover color

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf806fd63c8326b7ec92a470196c45