### PR TITLE
Link placeholder image remotely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ yarn-error.log*
 .env
 .env.*
 !.env.example
+
+# TypeScript
+*.tsbuildinfo

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,11 @@ export const metadata = {
   title: "Tokyo Curated — bespoke, human-led Tokyo itineraries",
   description: "50% more in 50% less time. Private driving concierge, secured reservations, and calm cadence — zero generic lists.",
   icons: [{ rel: "icon", url: "/favicon.ico" }],
+  openGraph: {
+    images: [
+      "https://gvwwl4nhmibwxszy.public.blob.vercel-storage.com/assets/placeholder.png",
+    ],
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- remove locally stored `placeholder.png`
- reference external placeholder image via `openGraph` metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfcedb33d083268439d5ba38f95a76