### PR TITLE
Use next/image for hero placeholder

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { motion } from "framer-motion";
+import Image from "next/image";
 
 const brand = {
   bg: "#0a0a0a",
@@ -358,15 +359,14 @@ export default function Page() {
           </div>
           <div className="md:col-span-5">
             <div
-              className="aspect-[4/5] w-full overflow-hidden rounded-3xl border"
+              className="relative aspect-[4/5] w-full overflow-hidden rounded-3xl border"
               style={{ borderColor: brand.ring, background: "linear-gradient(180deg,#151515,#0c0c0c)" }}
             >
-              <div
-                className="h-full w-full"
-                style={{
-                  background:
-                    "radial-gradient(800px 300px at 60% 20%, rgba(195,164,108,0.12), transparent)",
-                }}
+              <Image
+                src="https://gvwwl4nhmibwxszy.public.blob.vercel-storage.com/assets/placeholder.png"
+                alt="Tokyo skyline placeholder"
+                fill
+                className="object-cover"
               />
             </div>
             <p className="mt-3 text-xs" style={{ color: brand.sub }}>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,9 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true
+  },
+  images: {
+    domains: ["gvwwl4nhmibwxszy.public.blob.vercel-storage.com"],
   }
 };
 export default nextConfig;


### PR DESCRIPTION
## Summary
- render placeholder skyline image in hero using next/image
- allow external storage domain in Next.js config

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfdbce5cdc8326a9ee66879604b7ea