### PR TITLE
Remove placeholder social images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -44,21 +44,7 @@ body {
   height: 100%;
   border-radius: inherit;
   background: #0a0a0a;
-}
-
-.sparkle {
-  position: absolute;
-  top: 0.35rem;
-  right: 1rem;
-  font-size: 0.75rem;
-  color: #f7e7c0;
-  opacity: 0;
-  transform: scale(0);
-  pointer-events: none;
-}
-
-.cta-gold:hover .sparkle {
-  animation: sparkle 0.7s ease-out forwards;
+  white-space: nowrap;
 }
 
 @keyframes glimmer {
@@ -69,28 +55,8 @@ body {
     background-position: 200% 50%;
   }
 }
-
-@keyframes sparkle {
-  0% {
-    transform: scale(0) rotate(0deg);
-    opacity: 1;
-  }
-  80% {
-    transform: scale(1) rotate(180deg);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1.4) rotate(240deg);
-    opacity: 0;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .cta-gold::before {
     animation: none;
-  }
-  .cta-gold:hover .sparkle {
-    animation: none;
-    opacity: 1;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,11 +3,8 @@ export const metadata = {
   title: "Tokyo Curated — bespoke, human-led Tokyo itineraries",
   description: "50% more in 50% less time. Private driving concierge, secured reservations, and calm cadence — zero generic lists.",
   icons: [{ rel: "icon", url: "/favicon.ico" }],
-  openGraph: {
-    images: [
-      "https://gvwwl4nhmibwxszy.public.blob.vercel-storage.com/assets/placeholder.png",
-    ],
-  },
+  openGraph: {},
+  twitter: {},
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,6 @@ function CTAButton({ children, onClick }: { children: React.ReactNode; onClick?:
       style={{ color: brand.ink }}
     >
       <span>{children}</span>
-      <span className="sparkle">✦</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- remove placeholder Open Graph image
- clear Twitter image metadata
- drop hover sparkle animation and keep CTA text on one line

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfdd0b65308326be77914f960a54e1